### PR TITLE
update readme with hypriot styled examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ First, you define your app's environment with a `Dockerfile` so it can be
 reproduced anywhere:
 
 ```Dockerfile
-FROM python:2.7
+FROM hypriot/rpi-python:latest
 WORKDIR /code
 ADD requirements.txt /code/
 RUN pip install -r requirements.txt
@@ -35,7 +35,7 @@ web:
   ports:
    - "8000:8000"
 db:
-  image: postgres
+  image: hypriot/rpi-redis
 ```
 
 Lastly, run `docker-compose up` and Compose will start and run your entire app.


### PR DESCRIPTION
Since this is a fork of compose for the Pi, use sample images from the hypriot collection rather than from the default collection, since the provided examples are x86 based and will not run on the Pi.

Not sure that the whole README doesn't need to be updated, but this tripped me up the first time through trying to adapt compose examples from the net.
